### PR TITLE
Check if 'zone' is non-null before using it

### DIFF
--- a/keynav.c
+++ b/keynav.c
@@ -2097,12 +2097,14 @@ int main(int argc, char **argv) {
         break;
 
       case MotionNotify:
+        if (zone) {
         if (mouseinfo.x != -1 && mouseinfo.y != -1) {
           closepixel(dpy, zone, &mouseinfo);
         }
         mouseinfo.x = e.xmotion.x;
         mouseinfo.y = e.xmotion.y;
         openpixel(dpy, zone, &mouseinfo);
+        }
         break;
 
       // Ignorable events.


### PR DESCRIPTION
This seems to fix the following X11 error

Error of failed request:  BadWindow (invalid Window parameter)
  Major opcode of failed request:  129 (SHAPE)
  Minor opcode of failed request:  1 (X_ShapeRectangles)
  Resource id in failed request:  0x0

This error only happens occasionally, but causes keynav to crash