### PR TITLE
adds "lag" to introduce delay into recording playback, reset the lag …

### DIFF
--- a/keynav.c
+++ b/keynav.c
@@ -24,10 +24,7 @@
 #include <X11/extensions/Xrandr.h>
 #include <glib.h>
 #include <cairo-xlib.h>
-
-#ifdef PROFILE_THINGS
 #include <time.h>
-#endif
 
 #include <xdo.h>
 #include "keynav_version.h"
@@ -125,6 +122,8 @@ static struct appstate appstate = {
 };
 
 static int drag_button = 0;
+static int lag_default = 0;
+int lag = 0;
 static char drag_modkeys[128];
 
 /* history tracking */
@@ -162,6 +161,7 @@ void cmd_shell(char *args);
 void cmd_start(char *args);
 void cmd_warp(char *args);
 void cmd_windowzoom(char *args);
+void cmd_lag(char *args);
 
 void update();
 void correct_overflow();
@@ -234,6 +234,7 @@ dispatch_t dispatch[] = {
   "restart", cmd_restart,
   "record", cmd_record,
   "playback", cmd_playback,
+  "lag", cmd_lag,
   NULL, NULL,
 };
 
@@ -1017,6 +1018,7 @@ void cmd_end(char *args) {
   XUngrabKeyboard(dpy, CurrentTime);
 
   zone = 0;
+  lag = 0;
 }
 
 void cmd_toggle_start(char *args) {
@@ -1375,6 +1377,17 @@ void cmd_record(char *args) {
     appstate.recording = record_getkey;
   }
 }
+
+void cmd_lag(char *args) {
+  if (!ISACTIVE)
+    return;
+
+  if (args == NULL) {
+    lag = lag_default;
+  } else {
+    sscanf(args, "%d", &lag);
+  }
+} /* void cmd_lag */
 
 void update() {
   if (!ISACTIVE)
@@ -1739,6 +1752,7 @@ void handle_commands(char *commands) {
 
         found = 1;
         dispatch[i].func(args);
+        if (lag > 0) usleep(lag * 1000L);
       }
     }
 


### PR DESCRIPTION
I was having an issue with keynav playing back recordings faster than programs could respond, which was causing UI interactions to be missed. This change adds the ability to set in each recording a delay between dispatch events. Once set, a lag affects all dispatches until another lag call resets it. Example uses in recordings:

Slow down the entire interaction:
```
39  lag 10, cut-left, cut-left, cut-up, warp, click 3, cut-down, cut-up, cut-up, cut-right, cut-left, warp, click 1, end
```

Introduce a delay only at one troublesome point:
```
39  cut-left, cut-left, cut-up, warp, lag 20, click 3, lag 0, cut-down, cut-up, cut-up, cut-right, cut-left, warp, click 1, end
```

### Caveats and alternatives

- `lag` must be edited into the macro file by hand.
- `lag` is reset by `end`, but if a macro sets `lag` and doesn't unset it, it'll affect all other macros until either another `lag` or `end` is encountered. This is a consequence of the setting being recorded in global scope.
- `lag` could be a `sleep` command, which doesn't have global state and which only introduces a single sleep (each time). This would be fine in cases where a GUI interaction only races at specific points, but would be tedious if numerous sleeps must be introduced.

I think a `sleep` would be fine: in the one case I've found the second example was sufficient to address the issue, and I can't imagine macros get so complex that a `sleep` command would get that annoying. `lag` was a more general solution.  I'll provide both as PRs to choose from.